### PR TITLE
Fix is pytest fixture

### DIFF
--- a/pylint_pytest/utils.py
+++ b/pylint_pytest/utils.py
@@ -28,7 +28,6 @@ def _is_pytest_mark(decorator):
 
 
 def _is_pytest_fixture(decorator, fixture=True, yield_fixture=True):
-    attr = None
     to_check = set()
 
     if fixture:
@@ -37,18 +36,39 @@ def _is_pytest_fixture(decorator, fixture=True, yield_fixture=True):
     if yield_fixture:
         to_check.add('yield_fixture')
 
+    def _check_attribute(attr):
+        """
+        handle astroid.Attribute, i.e., when the fixture function is
+        used by importing the pytest module
+        """
+        return attr.attrname in to_check and attr.expr.name == 'pytest'
+
+    def _check_name(name_):
+        """
+        handle astroid.Name, i.e., when the fixture function is
+        directly imported
+        """
+        function_name = name_.name
+        module = decorator.root().globals.get(function_name, [None])[0]
+        module_name = module.modname if module else None
+        return function_name in to_check and module_name == 'pytest'
+
     try:
+        if isinstance(decorator, astroid.Name):
+            # expecting @fixture
+            return _check_name(decorator)
         if isinstance(decorator, astroid.Attribute):
             # expecting @pytest.fixture
-            attr = decorator
-
+            return _check_attribute(decorator)
         if isinstance(decorator, astroid.Call):
-            # expecting @pytest.fixture(scope=...)
-            attr = decorator.func
+            func = decorator.func
+            if isinstance(func, astroid.Name):
+                # expecting @fixture(scope=...)
+                return _check_name(func)
+            else:
+                # expecting @pytest.fixture(scope=...)
+                return _check_attribute(func)
 
-        if attr and attr.attrname in to_check \
-                and attr.expr.name == 'pytest':
-            return True
     except AttributeError:
         pass
 

--- a/tests/input/redefined-outer-name/direct_import.py
+++ b/tests/input/redefined-outer-name/direct_import.py
@@ -1,0 +1,28 @@
+from pytest import fixture
+
+
+@fixture
+def simple_decorator():
+    """the fixture using the decorator without executing it"""
+
+
+def test_simple_fixture(simple_decorator):
+    assert True
+
+
+@fixture()
+def un_configured_decorated():
+    """the decorated is called without argument, like scope"""
+
+
+def test_un_configured_decorated(un_configured_decorated):
+    assert True
+
+
+@fixture(scope="function")
+def configured_decorated():
+    """the decorated is called with argument, like scope"""
+
+
+def test_un_configured_decorated(configured_decorated):
+    assert True

--- a/tests/test_redefined_outer_name.py
+++ b/tests/test_redefined_outer_name.py
@@ -28,3 +28,9 @@ class TestRedefinedOuterName(BasePytestTester):
     def test_args_and_kwargs(self, enable_plugin):
         self.run_linter(enable_plugin)
         self.verify_messages(2)
+
+    @pytest.mark.parametrize('enable_plugin', [True, False])
+    def test_direct_import(self, enable_plugin):
+        """the fixture method is directly imported """
+        self.run_linter(enable_plugin)
+        self.verify_messages(0 if enable_plugin else 3)


### PR DESCRIPTION
Fixing _is_pytest_fixture

currently, both fixture in this example are flagged has not fixtures
```python
from pytest import fixture

@fixture
def my_fixture(): pass

@fixture(name="foo")
def my_fixture_2(): pass
```
This is due to the different semantics in astroid when using `import pytest` or `from pytest import ...`